### PR TITLE
[bugfix] Adds support for non-transpiled classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const VersionChecker = require('ember-cli-version-checker');
+const browserslist = require('browserslist');
 
 module.exports = {
   name: 'ember-legacy-class-shim',
@@ -16,7 +17,13 @@ module.exports = {
     const emberChecker = new VersionChecker(host).forEmber();
 
     if (!emberChecker.isAbove('2.13.0')) {
-      host.import('vendor/ember-legacy-class-shim.js');
+      const browsers = browserslist(this.project.targets.browsers);
+
+      if (browsers.find((browser) => browser.includes('ie'))) {
+        host.import('vendor/ember-legacy-class-shim-ie.js');
+      } else {
+        host.import('vendor/ember-legacy-class-shim.js');
+      }
     } else if (parent === host) {
       // The shim is being used in an application, and no longer needed
       host.project.ui.writeWarnLine(

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "browserslist": "^3.1.0",
     "ember-cli-version-checker": "^2.0.0"
   },
   "devDependencies": {

--- a/vendor/ember-legacy-class-shim-ie.js
+++ b/vendor/ember-legacy-class-shim-ie.js
@@ -1,5 +1,24 @@
 /* globals Ember, DS */
 (function() {
+  function _possibleConstructorReturn(self, call) {
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+
+    if (superClass) {
+      Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+    }
+  }
+
   var ExtendOverrideMixin = Ember.Mixin.create({
     extend: function() {
       if (Object.getPrototypeOf(this) === Function.prototype) {
@@ -11,7 +30,15 @@
       // Create a simple wrapper class to defer to the rest of the prototype chain
       // for native classes and classes that extend from native classes. This is the
       // output for creating classes from Babel, so it should be crosscompatible.
-      var Class = class extends this {};
+      var Class = function (_ref) {
+        _inherits(Class, _ref);
+
+        function Class() {
+          return _possibleConstructorReturn(this, (Class.__proto__ || Object.getPrototypeOf(Class)).apply(this, arguments));
+        }
+
+        return Class;
+      }(this);
 
       // Assign the name of the parent class for better logging and debugging
       Object.defineProperty(Class, 'name', { value: this.name || this.toString() })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,13 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000718"
     electron-to-chromium "^1.3.18"
 
+browserslist@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.1.0.tgz#6a1ccc302ddf48e70480e2ee1a9acc293eceb306"
+  dependencies:
+    caniuse-lite "^1.0.30000808"
+    electron-to-chromium "^1.3.33"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1587,6 +1594,10 @@ can-symlink@^1.0.0:
 caniuse-lite@^1.0.30000718:
   version "1.0.30000740"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000740.tgz#f2c4c04d6564eb812e61006841700ad557f6f973"
+
+caniuse-lite@^1.0.30000808:
+  version "1.0.30000808"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz#7d759b5518529ea08b6705a19e70dbf401628ffc"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2099,6 +2110,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.3.18:
   version "1.3.24"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz#9b7b88bb05ceb9fa016a177833cc2dde388f21b6"
+
+electron-to-chromium@^1.3.33:
+  version "1.3.33"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
 
 ember-ajax@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Browsers that actually support classes won't allow us to try to interop, so include a different path